### PR TITLE
Regenerate files from latest templates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ language: shell
       echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
+      opam repo -a --set-default add coq-extra-dev https://coq.inria.fr/opam/extra-dev
       opam update -y
       opam pin add ${PACKAGE} . -y -n -k path
       opam install ${PACKAGE} -y -j ${NJOBS} --deps-only

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis][travis-shield]][travis-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
-[![Gitter][gitter-shield]][gitter-link]
+[![Zulip][zulip-shield]][zulip-link]
 [![coqdoc][coqdoc-shield]][coqdoc-link]
 
 [travis-shield]: https://travis-ci.com/coq-community/huffman.svg?branch=master
@@ -15,8 +15,8 @@
 [conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
 [conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
 
-[gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
-[gitter-link]: https://gitter.im/coq-community/Lobby
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
 
 [coqdoc-shield]: https://img.shields.io/badge/docs-coqdoc-blue.svg
 [coqdoc-link]: https://coq-community.github.io/huffman/docs/latest/coqdoc/toc.html

--- a/default.nix
+++ b/default.nix
@@ -21,5 +21,5 @@ pkgs.stdenv.mkDerivation {
 
   src = if shell then null else ./.;
 
-  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+  installFlags = "COQMF_COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 }

--- a/resources/index.html
+++ b/resources/index.html
@@ -1,11 +1,19 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Huffman</title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <style>
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
   <style type="text/css"> body {font-family: Arial, Helvetica; margin-left: 5em; font-size: large;} </style>
   <style type="text/css"> h1 {margin-left: 0em; padding: 0px; text-align: center} </style>
   <style type="text/css"> h2 {margin-left: 0em; padding: 0px; color: #580909} </style>
@@ -13,15 +21,15 @@
   <style type="text/css"> body { width: 1100px; margin-left: 30px; }</style>
 </head>
 <body>
-<div id="header">
+<header id="title-block-header">
 <h1 class="title">Huffman</h1>
-</div>
+</header>
 <div style="text-align:left">
 <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px"> <a href="https://github.com/coq-community/huffman">View the project on GitHub</a> <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px">
 </div>
 <h2 id="about">About</h2>
 <p>Welcome to the Huffman project website! This project is part of <a href="https://github.com/coq-community/manifesto">coq-community</a>.</p>
-<p>This projects contains a Coq proof of the correctness of the Huffman coding algorithm, as described in David A. Huffman's paper A Method for the Construction of Minimum-Redundancy Codes, Proc. IRE, pp. 1098-1101, September 1952.</p>
+<p>This projects contains a Coq proof of the correctness of the Huffman coding algorithm, as described in David A. Huffman’s paper A Method for the Construction of Minimum-Redundancy Codes, Proc. IRE, pp. 1098-1101, September 1952.</p>
 <p>This is an open source project, licensed under the GNU Lesser General Public License v2.1 or later.</p>
 <h2 id="get-the-code">Get the code</h2>
 <p>The current stable release of Huffman can be <a href="https://github.com/coq-community/huffman/releases">downloaded from GitHub</a>.</p>
@@ -33,14 +41,14 @@
 </ul>
 <p>Other related publications, if any, are listed below.</p>
 <ul>
-<li><a href="https://hal.archives-ouvertes.fr/hal-02149909">Formalising Huffman's algorithm</a></li>
+<li><a href="https://hal.archives-ouvertes.fr/hal-02149909">Formalising Huffman’s algorithm</a></li>
 <li><a href="http://compression.ru/download/articles/huff/huffman_1952_minimum-redundancy-codes.pdf">A Method for the Construction of Minimum-Redundancy Codes</a> doi:<a href="https://doi.org/10.1109/JRPROC.1952.273898">10.1109/JRPROC.1952.273898</a></li>
 </ul>
 <h2 id="help-and-contact">Help and contact</h2>
 <ul>
 <li>Report issues on <a href="https://github.com/coq-community/huffman/issues">GitHub</a></li>
-<li>Chat with us on <a href="https://gitter.im/coq-community/Lobby">Gitter</a></li>
-<li>Discuss with us on Coq's <a href="https://coq.discourse.group">Discourse</a> forum</li>
+<li>Chat with us on <a href="https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users">Zulip</a></li>
+<li>Discuss with us on Coq’s <a href="https://coq.discourse.group">Discourse</a> forum</li>
 </ul>
 <h2 id="authors-and-contributors">Authors and contributors</h2>
 <ul>

--- a/resources/index.md
+++ b/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Huffman
+lang: en
 header-includes:
   - |
     <style type="text/css"> body {font-family: Arial, Helvetica; margin-left: 5em; font-size: large;} </style>
@@ -42,7 +43,7 @@ Other related publications, if any, are listed below.
 ## Help and contact
 
 - Report issues on [GitHub](https://github.com/coq-community/huffman/issues)
-- Chat with us on [Gitter](https://gitter.im/coq-community/Lobby)
+- Chat with us on [Zulip](https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users)
 - Discuss with us on Coq's [Discourse](https://coq.discourse.group) forum
 
 ## Authors and contributors


### PR DESCRIPTION
Includes a move from the Gitter badge to the Zulip badge in README.