### PR TITLE
switch to Dune-Coq 0.8

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,5 +1,3 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
 name: Docker CI
 
 on:
@@ -33,6 +31,10 @@ jobs:
         with:
           opam_file: 'coq-huffman.opam'
           custom_image: ${{ matrix.image }}
+          before_install: |
+            startGroup "Print opam config and unpin dune"
+              opam config list; opam repo list; opam list; opam pin remove dune
+            endGroup
 
 
 # See also:

--- a/coq-huffman.opam
+++ b/coq-huffman.opam
@@ -1,6 +1,3 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
-
 opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 version: "dev"
@@ -19,8 +16,8 @@ Codes, Proc. IRE, pp. 1098-1101, September 1952."""
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "dune" {>= "2.5"}
-  "coq" {(>= "8.12" & < "8.18~") | (= "dev")}
+  "dune" {>= "3.8"}
+  "coq" {>= "8.12"}
 ]
 
 tags: [

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.5)
-(using coq 0.2)
+(lang dune 3.8)
+(using coq 0.8)
 (name huffman)

--- a/meta.yml
+++ b/meta.yml
@@ -41,7 +41,7 @@ license:
 
 supported_coq_versions:
   text: 8.12 or later
-  opam: '{(>= "8.12" & < "8.18~") | (= "dev")}'
+  opam: '{>= "8.12"}'
 
 tested_coq_opam_versions:
 - version: 'dev'


### PR DESCRIPTION
This is an experimental PR to evaluate the feasibility of the new 3.8 series of releases of Dune with support for Coq composition with installed libraries. We are waiting for some Dune bugs to be fixed and for Docker images to be upgraded before this can go out of draft, notably ocaml/dune#7893 and coq-community/docker-coq#56